### PR TITLE
Increase mutation rate from 5% to 20%

### DIFF
--- a/genome.pde
+++ b/genome.pde
@@ -1,6 +1,6 @@
 // standard deviation of mutation added to each gene in meiosis
 static final float MUTATION_DEVIATION = 0.3;
-static final float MUTATION_RATE = 0.05;
+static final float MUTATION_RATE = 0.20;
 // standard deviation of initial gene values
 static final float INITIAL_DEVIATION = 0.05;
 // multiplier for number of genes given to each trait


### PR DESCRIPTION
For faster evolution!

@tsoule88 in addition to this, I believe you ran into an issue scaling fitness to number of gametes produced by an individual. See `nGametes()` in `population.pde`. Its purpose is to scale the fitness to about O(10), and when I switched to using the creature's width, I had to adjust the scaling by a factor of 100 to get a reasonable number of gametes. My guess is you were getting only a few gametes total, causing _really_ slow evolution, on top of the prior 5% rate.
