### PR TITLE
Refactor for "static" traits in Genome

### DIFF
--- a/creature.pde
+++ b/creature.pde
@@ -50,10 +50,10 @@ class creature {
     makeBody(new Vec2(x, y));   // call the function that makes a Box2D body
     body.setUserData(this);     // required by Box2D
     float energy_scale = 500; // scales the max energy pool size
-    float max_sum = abs(genome.maxReproductiveEnergy.sum()) + abs(genome.maxLocomotionEnergy.sum()) + abs(genome.maxHealthEnergy.sum());
-    max_energy_reproduction = body.getMass() * energy_scale * abs(genome.maxReproductiveEnergy.sum())/max_sum; // initial mass is around 150, so factor of 1000 gives reasonable energy storage.
-    max_energy_locomotion = body.getMass() * energy_scale * abs(genome.maxLocomotionEnergy.sum())/max_sum;
-    max_energy_health =  body.getMass() * energy_scale * abs(genome.maxHealthEnergy.sum())/max_sum;
+    float max_sum = abs(genome.sum(maxReproductiveEnergy)) + abs(genome.sum(maxLocomotionEnergy)) + abs(genome.sum(maxHealthEnergy));
+    max_energy_reproduction = body.getMass() * energy_scale * abs(genome.sum(maxReproductiveEnergy))/max_sum; // initial mass is around 150, so factor of 1000 gives reasonable energy storage.
+    max_energy_locomotion = body.getMass() * energy_scale * abs(genome.sum(maxLocomotionEnergy))/max_sum;
+    max_energy_health =  body.getMass() * energy_scale * abs(genome.sum(maxHealthEnergy))/max_sum;
     energy_reproduction = 0;    // have to collect energy to reproduce
     energy_locomotion = min(20000,max_energy_locomotion);  // start with energy for locomotion, the starting amount should come from the gamete and should be evolved
     energy_health = 0;          // have to collect energy to regenerate, later this may be evolved
@@ -86,10 +86,10 @@ class creature {
                         0.45 * worldWidth * cos(angle));
     makeBody(pos);
     float energy_scale = 500;
-    float max_sum = abs(genome.maxReproductiveEnergy.sum()) + abs(genome.maxLocomotionEnergy.sum()) + abs(genome.maxHealthEnergy.sum());
-    max_energy_reproduction = body.getMass() * energy_scale * abs(genome.maxReproductiveEnergy.sum())/max_sum; 
-    max_energy_locomotion = body.getMass() * energy_scale * abs(genome.maxLocomotionEnergy.sum())/max_sum;
-    max_energy_health =  body.getMass() * energy_scale * abs(genome.maxHealthEnergy.sum())/max_sum;
+    float max_sum = abs(genome.sum(maxReproductiveEnergy)) + abs(genome.sum(maxLocomotionEnergy)) + abs(genome.sum(maxHealthEnergy));
+    max_energy_reproduction = body.getMass() * energy_scale * abs(genome.sum(maxReproductiveEnergy))/max_sum; 
+    max_energy_locomotion = body.getMass() * energy_scale * abs(genome.sum(maxLocomotionEnergy))/max_sum;
+    max_energy_health =  body.getMass() * energy_scale * abs(genome.sum(maxHealthEnergy))/max_sum;
     energy_reproduction = 0;                                // have to collect energy to reproduce
     energy_locomotion = min(e,max_energy_locomotion);       // start with energy for locomotion, the starting amount should come from the gamete and should be evolved
     energy_health = 0;                                      // have to collect energy to regenerate, later this may be evolved
@@ -112,7 +112,7 @@ class creature {
     FloatList l;
     float s;
     int val;
-    l = c.genome.scent.list();
+    l = c.genome.list(scentTrait);
     s = l.get(5); // the 5th gene determines scent color for now
     // map function goes here
     if( s >= 0 ) {
@@ -125,7 +125,7 @@ class creature {
   // set scentStrength
   float setScentStrength( creature c ) {
     float s;
-    s = c.genome.scent.avg();
+    s = c.genome.avg(scentTrait);
     // mapping function goes here
     return s;
   }
@@ -133,7 +133,7 @@ class creature {
   // function setScent will calculate the creatures scent value
   boolean setScent( creature c ) {
     float s;
-    s = c.genome.scent.sum();
+    s = c.genome.sum(scentTrait);
     // need to add a mapping function here
     if( s >= 0 ) {
       return true;
@@ -177,9 +177,9 @@ class creature {
   // 255 centered on 126
   private color getColor() {
     // TODO: refactor for color per segment
-    float redColor = genome.redColor.sum();
-    float greenColor = genome.greenColor.sum();
-    float blueColor = genome.blueColor.sum();
+    float redColor = genome.sum(redColorTrait);
+    float greenColor = genome.sum(greenColorTrait);
+    float blueColor = genome.sum(blueColorTrait);
 
     int r = 126 + (int)(126*(redColor/(1+abs(redColor))));
     int g = 126 + (int)(126*(greenColor/(1+abs(greenColor))));
@@ -192,7 +192,7 @@ class creature {
   // the creatures body
   private Vec2 getPoint(int i) {
     Vec2 a = new Vec2();
-    float segment = genome.segments.get(i).endPoint.sum();
+    float segment = genome.sum(segments.get(i).endPoint);
     int lengthbase = 20;
     float l;
     if (segment < 0) {
@@ -211,7 +211,7 @@ class creature {
   private Vec2 getFlippedPoint(int i) {
     // TODO: reduce code duplication
     Vec2 a = new Vec2();
-    float segment = genome.segments.get(i).endPoint.sum();
+    float segment = genome.sum(segments.get(i).endPoint);
     int lengthbase = 20;
     float l;
     if (segment < 0) {
@@ -264,24 +264,24 @@ class creature {
   // (currently) doesn't change anytime durning a wave
   private float getForce() {
     // -infinity to infinity linear
-    return (500 + 10 * genome.forwardForce.sum());
+    return (500 + 10 * genome.sum(forwardForce));
   }
 
   // How bouncy a creature is, one of the basic box2D body parameters,
   // no idea how it evolves or if it has any value to the creatures
   private float getRestitution() {
     // TODO: refactor for restitution per segment
-    float r = genome.restitution.sum();
+    float r = genome.sum(restitutionTrait);
     return 0.5 + (0.5 * (r / (1 + abs(r))));
   }
 
   // can be from 2 to Genome.MAX_SEGMENTS
   int getNumSegments() {
-    int ret = round(genome.expressedSegments.avg() + 8);
+    int ret = round(genome.avg(expressedSegments) + 8);
     if (ret < 2)
       return 2;
-    if (ret > Genome.MAX_SEGMENTS)
-      return Genome.MAX_SEGMENTS;
+    if (ret > MAX_SEGMENTS)
+      return MAX_SEGMENTS;
     return ret;
   }
 
@@ -294,18 +294,18 @@ class creature {
     // TODO: refactor for density per segment
 
     // if the value is negative, density approaches zero asympototically from 10
-    if (genome.density.sum() < 0)
-      return 10 * (1 / (1 + abs(genome.density.sum())));
+    if (genome.sum(densityTrait) < 0)
+      return 10 * (1 / (1 + abs(genome.sum(densityTrait))));
     // otherwise, the value is positive and density grows as 10 plus the square
     // root of the evolved value
-    return 10 + sqrt(genome.density.sum()); // limit 0 to infinity
+    return 10 + sqrt(genome.sum(densityTrait)); // limit 0 to infinity
   }
 
   private void computeArmor() {
     armor = new FloatList(numSegments);
     for (int i = 0; i < numSegments; i++) {
       // compute armor value for each segment [0.1, infinity]
-      float a = genome.segments.get(i).armor.avg();
+      float a = genome.avg(segments.get(i).armor);
       if (1 + a < 0.1)
         a = 0.1;
       else
@@ -329,14 +329,14 @@ class creature {
   // turning
   private int getTurningForce() {
     // -infinity to infinity linear
-    return (int)(100 + 10 * genome.turningForce.sum());
+    return (int)(100 + 10 * genome.sum(turningForce));
   }
 
   // Returns the amount of turning force (just a decimal number) the
   // creature has evolved to apply when it senses either food, another
   // creature, a rock, or a (food) scent.
-  private double getBehavior(Genome.Trait trait) {
-    return getTurningForce() * trait.sum(); // there's a turning force
+  private double getBehavior(Trait trait) {
+    return getTurningForce() * genome.sum(trait); // there's a turning force
   }
 
   // This function calculates the torques the creature produces to turn, as a 
@@ -368,21 +368,21 @@ class creature {
     // Set the torque to zero, then add in the effect of the sensors
     double torque = 0;
     // If there's food ahead on the left, turn by the evolved torque
-    torque += foodAheadL * getBehavior(genome.food);
+    torque += foodAheadL * getBehavior(foodTrait);
     // If there's food ahead on the right, turn by the evolved torque
     // but in the opposite direction
-    torque += foodAheadR * -1 * getBehavior(genome.food);
+    torque += foodAheadR * -1 * getBehavior(foodTrait);
     // Similar turns for creatures and rocks
-    torque += creatureAheadL * getBehavior(genome.creature);
-    torque += creatureAheadR * -1 * getBehavior(genome.creature);
-    torque += rockAheadL * getBehavior(genome.rock);
-    torque += rockAheadR * -1 * getBehavior(genome.rock);
+    torque += creatureAheadL * getBehavior(creatureTrait);
+    torque += creatureAheadR * -1 * getBehavior(creatureTrait);
+    torque += rockAheadL * getBehavior(rockTrait);
+    torque += rockAheadR * -1 * getBehavior(rockTrait);
     // Take the square root of the amout of scent detected on the left
     // (right), factor in the evolved response to smelling food, and
     // add that to the torque Take the squareroot of the scent to
     // reduce over correction
-    torque += sqrt(scentAheadL) * getBehavior(genome.scent);
-    torque += sqrt(scentAheadR) * -1 * getBehavior(genome.scent);
+    torque += sqrt(scentAheadL) * getBehavior(scentTrait);
+    torque += sqrt(scentAheadR) * -1 * getBehavior(scentTrait);
     //println(torque);
     return torque;
   }

--- a/genome.pde
+++ b/genome.pde
@@ -1,121 +1,99 @@
-// Represents a creature's genomic data as an array of real values,
-// loosely modeling Additive Quantitative Genetics.
-class Genome {
-  // a pair of chromosomes is the genome
-  Chromosome xChromosome;
-  Chromosome yChromosome;
-  // standard deviation of mutation added to each gene in meiosis
-  static final float MUTATION_DEVIATION = 0.3;
-  static final float MUTATION_RATE = 0.05;
-  // standard deviation of initial gene values
-  static final float INITIAL_DEVIATION = 0.05;
-  // multiplier for number of genes given to each trait (for
-  // protective dead code)
-  static final float GENE_MULTIPLIER = 4.0/3.0;
-  // additional control trait to estimate genetic evolution
-  Trait control = new Trait(10);
+// standard deviation of mutation added to each gene in meiosis
+static final float MUTATION_DEVIATION = 0.3;
+static final float MUTATION_RATE = 0.05;
+// standard deviation of initial gene values
+static final float INITIAL_DEVIATION = 0.05;
+// multiplier for number of genes given to each trait
+static final float GENE_MULTIPLIER = 4.0/3.0;
 
-  // Metabolism
-  Trait maxReproductiveEnergy = new Trait(10);
-  Trait maxLocomotionEnergy = new Trait(10);
-  Trait maxHealthEnergy = new Trait(10);
-  static final int METABOLIC_WEIGHTS = metabolic_network.num_weights;
-  ArrayList<Trait> metabolicNetwork = new ArrayList<Trait>(METABOLIC_WEIGHTS);
+// additional control trait to estimate genetic evolution
+Trait control = new Trait(10);
 
-  // Reproduction
-  Trait gameteCost = new Trait(10);
-  Trait gameteTime = new Trait(10);
-  Trait gameteChance = new Trait(10);
-  Trait gameteEnergy = new Trait(10);
+// Metabolism
+Trait maxReproductiveEnergy = new Trait(10);
+Trait maxLocomotionEnergy = new Trait(10);
+Trait maxHealthEnergy = new Trait(10);
+static final int METABOLIC_WEIGHTS = metabolic_network.num_weights;
+ArrayList<Trait> metabolicNetwork = new ArrayList<Trait>(METABOLIC_WEIGHTS);
 
-  // Weights for the brain's artificial neural network
-  static final int BRAIN_INPUTS = 10;
-  static final int BRAIN_OUTPUTS = 100;
-  ArrayList<Trait> brain = new ArrayList<Trait>(BRAIN_INPUTS);
+// Reproduction
+Trait gameteCost = new Trait(10);
+Trait gameteTime = new Trait(10);
+Trait gameteChance = new Trait(10);
+Trait gameteEnergy = new Trait(10);
 
-  // Speciation
-  Trait compatibility = new Trait(10);
-  Trait reproductionEnergy = new Trait(10);
+// Weights for the brain's artificial neural network
+static final int BRAIN_INPUTS = 10;
+static final int BRAIN_OUTPUTS = 100;
+ArrayList<Trait> brainTraits = new ArrayList<Trait>(BRAIN_INPUTS);
 
-  // Environment interaction
-  Trait forwardForce = new Trait(10);
-  Trait turningForce = new Trait(10);
-  Trait food = new Trait(10);
-  Trait creature = new Trait(10);
-  Trait rock = new Trait(10);
+// Speciation
+Trait compatibility = new Trait(10);
+Trait reproductionEnergy = new Trait(10);
 
-  // Body
-  // TODO: add gender
-  Trait scent = new Trait(10);
-  // maximum number of segments/ribs/spines that can be evolved
-  static final int MAX_SEGMENTS = 20;
-  // need an extra point for the leading and trailing edge (spine)
-  ArrayList<Segment> segments = new ArrayList<Segment>(MAX_SEGMENTS + 1);
-  // encodes number of segments actually expressed
-  Trait expressedSegments = new Trait(10);
+// Environment interaction
+Trait forwardForce = new Trait(10);
+Trait turningForce = new Trait(10);
+Trait foodTrait = new Trait(10);
+Trait creatureTrait = new Trait(10);
+Trait rockTrait = new Trait(10);
 
-  // TODO: remove these traits when segment refactor is complete
-  Trait redColor = new Trait(10);
-  Trait greenColor = new Trait(10);
-  Trait blueColor = new Trait(10);
-  Trait density = new Trait(10);
-  Trait restitution = new Trait(10);
+// Body
+Trait scentTrait = new Trait(10);
 
-  private int nGenes = 0;
+// maximum number of segments/ribs/spines that can be evolved
+static final int MAX_SEGMENTS = 20;
+// need an extra point for the leading and trailing edge (spine)
+ArrayList<Segment> segments = new ArrayList<Segment>(MAX_SEGMENTS + 1);
+// encodes number of segments actually expressed
+Trait expressedSegments = new Trait(10);
 
-  // Represents a trait with a number of genes/loci and its index in the genome
-  class Trait {
-    int genes;
-    int index;
-    // TODO: allow custom range with scaling
+// TODO: remove these traits when segment refactor is complete
+Trait redColorTrait = new Trait(10);
+Trait greenColorTrait = new Trait(10);
+Trait blueColorTrait = new Trait(10);
+Trait densityTrait = new Trait(10);
+Trait restitutionTrait = new Trait(10);
 
-    Trait(int g) {
-      // For each trait, assign its index and count its genes
-      genes = g;
-      index = nGenes;
-      // add an extra GENE_MULTIPLIER number of genes to the end of
-      // each trait for even distribution of control (dead) genes
-      nGenes += round(GENE_MULTIPLIER * g);
-    }
+private int nGenes = 0;
 
-    // Returns a list of with 2 * genes number of floats
-    FloatList list() {
-      FloatList l = xChromosome.genes.getSubset(index, genes);
-      l.append(yChromosome.genes.getSubset(index, genes));
-      return l;
-    }
+// Represents a trait with a number of genes/loci and its index in the genome
+class Trait {
+  int genes;
+  int index;
+  // TODO: allow custom range with scaling
 
-    // Returns the sum of the genes from both chromosomes for the trait
-    float sum() {
-      return list().sum();
-    }
-
-    // Returns the average of the genes of a trait
-    float avg() {
-      return sum()/(genes * 2);
-    }
+  Trait(int g) {
+    // For each trait, assign its index and count its genes
+    genes = g;
+    index = nGenes;
+    // add an extra GENE_MULTIPLIER number of genes to the end of
+    // each trait for even distribution of control (dead) genes
+    nGenes += round(GENE_MULTIPLIER * g);
   }
+}
 
-  class Segment {
-    Trait endPoint;
-    Trait redColor;
-    Trait greenColor;
-    Trait blueColor;
-    Trait armor;
-    Trait density;
-    Trait restitution;
+class Segment {
+  Trait endPoint;
+  Trait redColor;
+  Trait greenColor;
+  Trait blueColor;
+  Trait armor;
+  Trait density;
+  Trait restitution;
 
-    Segment() {
-      endPoint    = new Trait(10);
-      redColor    = new Trait(10);
-      greenColor  = new Trait(10);
-      blueColor   = new Trait(10);
-      armor       = new Trait(10);
-      density     = new Trait(10);
-      restitution = new Trait(10);
-    }
+  Segment() {
+    endPoint    = new Trait(10);
+    redColor    = new Trait(10);
+    greenColor  = new Trait(10);
+    blueColor   = new Trait(10);
+    armor       = new Trait(10);
+    density     = new Trait(10);
+    restitution = new Trait(10);
   }
+}
 
+// "Static" initialization of trait lists
   {
     // initialize the metabolic weights
     for (int i = 0; i < METABOLIC_WEIGHTS; i++) {
@@ -124,7 +102,7 @@ class Genome {
 
     // initialize the brain weights
     for (int i = 0; i < BRAIN_INPUTS; i++) {
-      brain.add(new Trait(BRAIN_OUTPUTS));
+      brainTraits.add(new Trait(BRAIN_OUTPUTS));
     }
 
     // initialize the segments and their traits
@@ -132,6 +110,13 @@ class Genome {
       segments.add(new Segment());
     }
   }
+
+// Represents a creature's genomic data as an array of real values,
+// loosely modeling Additive Quantitative Genetics.
+class Genome {
+  // a pair of chromosomes is the genome
+  Chromosome xChromosome;
+  Chromosome yChromosome;
 
   // creates two new chromosomes
   Genome() {
@@ -143,6 +128,42 @@ class Genome {
   Genome(Chromosome x, Chromosome y) {
     xChromosome = x;
     yChromosome = y;
+  }
+
+  // Returns a list of genes from the X chromosome
+  FloatList listX(Trait trait) {
+    return xChromosome.list(trait);
+  }
+
+  // Returns a list of genes from the Y chromosome
+  FloatList listY(Trait trait) {
+    return yChromosome.list(trait);
+  }
+
+  // Returns a combined list of genes from both chromosomes
+  FloatList list(Trait trait) {
+    FloatList l = listX(trait);
+    l.append(listY(trait));
+    return l;
+  }
+
+  // Returns the sum of the genes from the X chromosome
+  float sumX(Trait trait) {
+    return xChromosome.sum(trait);
+  }
+
+  // Returns the sum of the genes from the Y chromosome
+  float sumY(Trait trait) {
+    return yChromosome.sum(trait);
+  }
+
+  // Returns the sum of the genes from both chromosomes
+  float sum(Trait trait) {
+    return sumX(trait) + sumY(trait);
+  }
+
+  float avg(Trait trait) {
+    return (xChromosome.avg(trait) + yChromosome.avg(trait)) / 2;
   }
 
   class Chromosome {
@@ -158,6 +179,18 @@ class Genome {
 
     Chromosome(Chromosome chromosome) {
       genes = chromosome.genes.copy();
+    }
+
+    FloatList list(Trait trait) {
+      return genes.getSubset(trait.index, trait.genes);
+    }
+
+    float sum(Trait trait) {
+      return list(trait).sum();
+    }
+
+    float avg(Trait trait) {
+      return sum(trait) / trait.genes;
     }
 
     void mutate() {

--- a/metabolic_network.pde
+++ b/metabolic_network.pde
@@ -21,7 +21,7 @@ class metabolic_network{
   metabolic_network(Genome genome){
     weights = new float[num_weights];
     for(int i = 0; i < num_weights; i++){
-      weights[i] = genome.metabolicNetwork.get(i).sum(); //randomGaussian();  // these X weights will come from the genome
+      weights[i] = genome.sum(metabolicNetwork.get(i)); //randomGaussian();  // these X weights will come from the genome
     }
   }
   

--- a/population.pde
+++ b/population.pde
@@ -117,14 +117,11 @@ class population {
     // "most compatibility" value // left or right of zero
     double mean = 0.0;
 
-    Genome genome1 = new Genome(gamete1, gamete1);
-    Genome genome2 = new Genome(gamete2, gamete2);
-
     // This is the location to evaluate the probability.  The further
     // away from the center of the curve, the less likely to be
     // compatible.
-    double x_val = Utilities.Sigmoid(genome1.compatibility.sum(), 50, 50)
-      - Utilities.Sigmoid(genome2.compatibility.sum(), 50, 50);
+    double x_val = Utilities.Sigmoid(gamete1.sum(compatibility), 50, 50)
+      - Utilities.Sigmoid(gamete2.sum(compatibility), 50, 50);
 
     double r = Math.random();
 


### PR DESCRIPTION
Instead of using static in Processing, since the preprocessor inserts
everything into a single instance of PApplet, moving the traits outside
the genome (as "globals") initializes them only once.

Traits can now be queried on a per-chromosome basis.

The interface for genome values is now closer to our original plan.

@tsoule88 This is the same PR but rebased onto master. We should merge it soon if we're going to merge it ever. It does make the next generation step happen a bit faster.
