### PR TITLE
Zoom out camera by default

### DIFF
--- a/evolvedTD.pde
+++ b/evolvedTD.pde
@@ -60,7 +60,7 @@ void setup() {
   frameRate(200);                // sets the framerate, in many cases the actual framerate will be lower due to the number of objects moving nad interacting
   cameraX = 0;
   cameraY = 0;
-  cameraZ = 300;
+  cameraZ = 2150;
   the_pop = new population();
 
   place_food();                  // calls the place food function below


### PR DESCRIPTION
I don't like using a magic number here, but it's the Z setting for the
"zoom out" command in the menu. I think we probably all would prefer it
to default to being zoomed out.
