### PR TITLE
Renamed appendages to feelers

### DIFF
--- a/Senses.pde
+++ b/Senses.pde
@@ -39,7 +39,7 @@ class Sensory_Systems {
   int b_angle = 813;
 
 
-  int num_appendages;
+  int num_feelers;
   //Pain varaibles
   boolean pain; /*perhaps evolve not to have pain*/
   float pain_current, pain_dampening, pain_threshold;
@@ -47,18 +47,18 @@ class Sensory_Systems {
   //Pressure
   boolean pressure;
   float pressure_ground, pressure_side;
-  int pressure_appendages;
+  int pressure_feelers;
 
   //Temperature feeling
   boolean temperature;
-  int temperature_appendages;
+  int temperature_feelers;
 
   //Taste/Receptors
-  int taste_appendages;
+  int taste_feelers;
   boolean taste;
 
   //Scent
-  int scent_appendages;
+  int scent_feelers;
 
   //Speed/balance receptors
   boolean speed = false;
@@ -71,9 +71,9 @@ class Sensory_Systems {
   float [] apend_length;
   float [] pressure_side_ids;
 
-  boolean [] appendage_pressure;
-  boolean [] appendage_taste;
-  boolean [] appendage_scent;
+  boolean [] feeler_pressure;
+  boolean [] feeler_taste;
+  boolean [] feeler_scent;
 
   Sensory_Systems(Genome g) {
     brain_array = new float[1000];
@@ -111,53 +111,53 @@ class Sensory_Systems {
 
     Set_Pain(pain, 0, abs((float)Utilities.Sigmoid(g.sum(painDampeningTrait), 5, 1)), abs((float)Utilities.Sigmoid(g.sum(painThresholdTrait), 5, 100))); /*Has pain, pain amount currentlyu, pain_dampening, pain_threshold*/
 
-    num_appendages = (int)abs((float)Utilities.Sigmoid(g.sum(expressedAppendages), 1, 38));
+    num_feelers = (int)abs((float)Utilities.Sigmoid(g.sum(expressedFeelers), 1, 38));
 
-    apend_angles = new float[num_appendages];
-    apend_length = new float[num_appendages];
+    apend_angles = new float[num_feelers];
+    apend_length = new float[num_feelers];
     pressure_side_ids = new float[40];
 
-    appendage_pressure = new boolean[num_appendages];
-    appendage_taste = new boolean[num_appendages];
-    appendage_scent = new boolean[num_appendages];
+    feeler_pressure = new boolean[num_feelers];
+    feeler_taste = new boolean[num_feelers];
+    feeler_scent = new boolean[num_feelers];
 
-    Set_Appendage(g);
+    Set_Feeler(g);
   }
 
   /*For the brain*/
   float [] Get_Brain_Array() { return brain_array; };
 
 
-  /*Determines what appendages can do and the lengths and angles of each*/
-  void Set_Appendage(Genome g) {
-    for (int i = 0; i < num_appendages; i++) {
+  /*Determines what feelers can do and the lengths and angles of each*/
+  void Set_Feeler(Genome g) {
+    for (int i = 0; i < num_feelers; i++) {
 
-      apend_angles[i]= abs((float)Utilities.Sigmoid(g.sum(appendages.get(i).angle), 3, 2*PI));
-      apend_length[i] = abs((float)Utilities.Sigmoid(g.sum(appendages.get(i).length), 5, 100));
+      apend_angles[i]= abs((float)Utilities.Sigmoid(g.sum(feelers.get(i).angle), 3, 2*PI));
+      apend_length[i] = abs((float)Utilities.Sigmoid(g.sum(feelers.get(i).length), 5, 100));
 
-      if (Utilities.Sigmoid(g.sum(appendages.get(i).pressure), 5, 1) > 0) {
-        appendage_pressure[i] = true;
+      if (Utilities.Sigmoid(g.sum(feelers.get(i).pressure), 5, 1) > 0) {
+        feeler_pressure[i] = true;
       } else {
-        appendage_pressure[i] = true;
+        feeler_pressure[i] = true;
       }
 
-      if (Utilities.Sigmoid(g.sum(appendages.get(i).taste), 5, 1) > 0) {
-        appendage_taste[i] = true;
+      if (Utilities.Sigmoid(g.sum(feelers.get(i).taste), 5, 1) > 0) {
+        feeler_taste[i] = true;
       } else {
-        appendage_taste[i] = false;
+        feeler_taste[i] = false;
       }
 
-      if (Utilities.Sigmoid(g.sum(appendages.get(i).scent), 5, 1) > 0) {
-        appendage_scent[i] = true;
+      if (Utilities.Sigmoid(g.sum(feelers.get(i).scent), 5, 1) > 0) {
+        feeler_scent[i] = true;
       } else {
-        appendage_scent[i] = false;
+        feeler_scent[i] = false;
       }
     }
   }
   
   /*Goes through each feelers and updates the senses it can interpret*/
   void Update_Senses(float x, float y, float angle) {
-    for (int i = 0; i < num_appendages;  i++) {
+    for (int i = 0; i < num_feelers;  i++) {
       Update_Sense(x, y, angle, apend_angles[i], apend_length[i], i);
     }
   }
@@ -174,8 +174,8 @@ class Sensory_Systems {
     sensorX = round((sensorX) / 20) * 20;
     sensorY = round((sensorY) / 20) * 20;
 
-    /*If appendage can feel pressure*/
-    if (appendage_pressure[i]) {
+    /*If feeler can feel pressure*/
+    if (feeler_pressure[i]) {
       if (environ.checkForRock(sensorX, sensorY) == 1) {
         brain_array[b_pressure_feeler + i] = ROCK_PRESSURE;
       } else if (environ.checkForCreature(sensorX, sensorY) == 1) {
@@ -185,8 +185,8 @@ class Sensory_Systems {
       }
     }
 
-    /*If appendage can taste*/
-    if (appendage_taste[i]) {
+    /*If feeler can taste*/
+    if (feeler_taste[i]) {
       int []tmp_taste = environ.checkForTaste(sensorX, sensorY);
       if (tmp_taste != null) {
         brain_array[b_taste_feelers+i] = tmp_taste[0];
@@ -202,8 +202,8 @@ class Sensory_Systems {
         brain_array[b_taste_feelers+i+4] = 0;        
       }
     }
-    /*If appendage can pick up smell*/
-    if (appendage_scent[i]) {
+    /*If feeler can pick up smell*/
+    if (feeler_scent[i]) {
       brain_array[b_scent_feelers+i] = environ.getScent(sensorX, sensorY);
     }
 
@@ -232,16 +232,16 @@ class Sensory_Systems {
 
   }
 
-  /*This functions calls Draw_Appendage
-  for each appendage the creature has*/
+  /*This functions calls Draw_Feeler
+  for each feeler the creature has*/
   void Draw_Sense(float x, float y, float angle) {
-    for (int i = 0; i < num_appendages;  i++) {
-      Draw_Appendage(x, y, angle, apend_angles[i], apend_length[i]);
+    for (int i = 0; i < num_feelers;  i++) {
+      Draw_Feeler(x, y, angle, apend_angles[i], apend_length[i]);
     }
   }
 
   /*This function draws the feelers for the creature*/
-  void Draw_Appendage(float x, float y, float angle, float evolved_angle, float evolved_length) {
+  void Draw_Feeler(float x, float y, float angle, float evolved_angle, float evolved_length) {
     // Draw the "feelers", this is mostly for debugging
     float sensorX,sensorY;
     sensorX = x + evolved_length * cos(-1 * (angle + PI+evolved_angle));
@@ -281,7 +281,7 @@ class Sensory_Systems {
     }
   }
 
-  /*Gets the basic stats of the cruture such as velocity, mass
+  /*Gets the basic stats of the creature such as velocity, mass
   momentum, health and movement*/
   void Set_Stats(creature c) {
     if (speed) {
@@ -305,7 +305,7 @@ class Sensory_Systems {
   }
 
 
-/* Since fixtures do not work the way I expected I need to d a tricky thing to detect pressure on side
+/* Since fixtures do not work the way I expected I need to do a tricky thing to detect pressure on side
    in the contact and endcontact function in evolveTD, if two creatures touch, a unique key is created, the largest
    is kept and then the ID is added, and the angle is added to the brain*/
    

--- a/environment.pde
+++ b/environment.pde
@@ -151,7 +151,7 @@ class environment{
     environHeight = worldHeight / cellHeight;
     environAltitude = (int)random(255);
     temp = (int)random(-40, 50); // celcius
-    println(temp);
+    //println(temp);
     rockFrequency = 0;
 
     gravityMap = new gravityVector[environHeight][environWidth];
@@ -368,7 +368,7 @@ class environment{
         // change values here and reconstruct color
       }
     }
-    println("red: " + r + " blue: " + b + " green: " + g);
+    //println("red: " + r + " blue: " + b + " green: " + g);
   }
 
   void place_creature(creature cd, float x, float y) {

--- a/genome.pde
+++ b/genome.pde
@@ -44,12 +44,12 @@ ArrayList<Segment> segments = new ArrayList<Segment>(MAX_SEGMENTS + 1);
 // encodes number of segments actually expressed
 Trait expressedSegments = new Trait(10);
 
-// maximum number of apendages that can be evolved
-static final int MAX_APPENDAGES = 40;
-ArrayList<AppendageTrait> appendages
-  = new ArrayList<AppendageTrait>(MAX_APPENDAGES);
-// encodes number of appendages actually expressed
-Trait expressedAppendages = new Trait(10);
+// maximum number of feelers that can be evolved
+static final int MAX_FEELERS = 40;
+ArrayList<FeelerTrait> feelers
+  = new ArrayList<FeelerTrait>(MAX_FEELERS);
+// encodes number of feelers actually expressed
+Trait expressedFeelers = new Trait(10);
 
 // sensory thresholds
 Trait painTrait = new Trait(10);
@@ -105,14 +105,14 @@ class Segment {
   }
 }
 
-class AppendageTrait {
+class FeelerTrait {
   Trait scent;
   Trait pressure;
   Trait taste;
   Trait angle;
   Trait length;
 
-  AppendageTrait() {
+  FeelerTrait() {
     scent    = new Trait(10);
     pressure = new Trait(10);
     taste    = new Trait(10);
@@ -138,9 +138,9 @@ class AppendageTrait {
       segments.add(new Segment());
     }
 
-    // initialize the appendages and their traits
-    for (int i = 0; i < (MAX_APPENDAGES); i++) {
-      appendages.add(new AppendageTrait());
+    // initialize the feelers and their traits
+    for (int i = 0; i < (MAX_FEELERS); i++) {
+      feelers.add(new FeelerTrait());
     }
 
     // initialize the color network weights


### PR DESCRIPTION
From very early on, appendages were to be the creatures' legs and arms
and used for primarily locomotion. These sensory mechanisms shouldn't
share the same name, as that just gets confusing. Henceforth they are
known as feelers, or whatever you guys want them to be called as long
as it's not appendages.
