### PR TITLE
I fixed the density getter

### DIFF
--- a/creature.pde
+++ b/creature.pde
@@ -60,6 +60,7 @@ class creature {
   float max_energy_locomotion;
   float max_energy_health;
   int regen_energy_cost = 5; // value to determine how much regenerating health costs
+  float density;
   metabolic_network metabolism;
 
   // senses/communication
@@ -88,7 +89,7 @@ class creature {
 
   ArrayList<Segment> segments = new ArrayList<Segment>(numSegments);
   ArrayList<Appendage> appendages = new ArrayList<Appendage>(numSegments);
-  
+
   // Data Collection variables
   float total_energy_space;
   float total_energy_consumed = 0;
@@ -98,7 +99,7 @@ class creature {
   float health_used = 0;
   int   hits_by_tower = 0;
   int   hp_removed_by_tower = 0;
-  
+
 
   class Segment {
     int index;
@@ -107,15 +108,21 @@ class creature {
     float restitution;
     Vec2 frontPoint;
     Vec2 backPoint;
+    float area;
 
     Segment(int i) {
       index = i;
       armor = getArmor();
-      density = getDensity();
+      density = getSegmentDensity();
       density *= armor;
       restitution = getRestitution();
       frontPoint = getFrontPoint();
       backPoint = getBackPoint();
+      area = getArea();
+    }
+
+    private float getArea() {
+      return (((sqrt((frontPoint.x*frontPoint.x)+(frontPoint.y*frontPoint.y))*sqrt((backPoint.x*backPoint.x)+(backPoint.y*backPoint.y)))/2)*(sin(PI/numSegments)));
     }
 
     private float getArmor() {
@@ -124,7 +131,7 @@ class creature {
       return (a+1);
     }
 
-    private float getDensity() {
+    private float getSegmentDensity() {
       float d = (genome.sum(segmentTraits.get(index).density));
       // if the value is negative, density approaches zero asympototically from 10
       if (d < 0)
@@ -193,13 +200,14 @@ class creature {
     Vec2 originPoint;
     Vec2 frontPoint;
     Vec2 backPoint;
+    float area;
 
     Appendage(int i) {
       index = i;
       size = getSize();
       if (size>0) {
         armor = getArmor();
-        density = getDensity();
+        density = getAppendageDensity();
         density *= armor;
         getForces();
         angle = getAngle();
@@ -207,7 +215,12 @@ class creature {
         originPoint = getOriginPoint();
         frontPoint = getFrontPoint();
         backPoint = getBackPoint();
+        area = getArea();
       }
+    }
+
+    private float getArea() {
+      return (((sqrt(((originPoint.x-frontPoint.x)*(originPoint.x-frontPoint.x))+((originPoint.y-frontPoint.y)*(originPoint.y-frontPoint.y)))*sqrt(((originPoint.x-backPoint.x)*(originPoint.x-backPoint.x))+((originPoint.y-backPoint.y)*(originPoint.y-backPoint.y))))/2)*(sin(spread)));
     }
 
     private float getSize() {
@@ -223,7 +236,7 @@ class creature {
       return (a+1);
     }
 
-    private float getDensity() {
+    private float getAppendageDensity() {
       float d = (genome.sum(appendageTraits.get(index).density));
       // if the value is negative, density approaches zero asympototically from 10
       if (d < 0)
@@ -304,18 +317,18 @@ class creature {
     construct(e, pos);
   }
 
-  void construct(float e, Vec2 pos) { // this function contains all the overlap of the constructors  
+  void construct(float e, Vec2 pos) { // this function contains all the overlap of the constructors
     num = creature_count++;
     senses = new Sensory_Systems(genome);
     brain = new Brain(genome);
     genome.inheritance(num);
- 
+
     current_actions = new float[brain.OUTPUTS];
-    
+
     // used for data collection
     sPos = pos.clone();
     total_energy_space = max_energy_locomotion + max_energy_reproduction + max_energy_health;
-    
+
 
     numSegments = getNumSegments();
     for (int i = 0; i < numSegments; i++) segments.add(new Segment(i));
@@ -323,6 +336,7 @@ class creature {
 
     makeBody(pos);   // call the function that makes a Box2D body
     body.setUserData(this);     // required by Box2D
+    density = getCreatureDensity();
 
     float energy_scale = 500; // scales the max energy pool size
     float max_sum = abs(genome.sum(maxReproductiveEnergy)) + abs(genome.sum(maxLocomotionEnergy)) + abs(genome.sum(maxHealthEnergy));
@@ -452,7 +466,7 @@ class creature {
     energy_reproduction = min(energy_reproduction, max_energy_reproduction);
     energy_locomotion = min(energy_locomotion, max_energy_locomotion);
     energy_health = min(energy_health, max_energy_health);
-    
+
     // data collection
     total_energy_consumed += x;
   }
@@ -492,7 +506,7 @@ class creature {
     g = g*(1 + (int)outputs[1]);
     b = b*(1 + (int)outputs[2]);
     a = a*(1 + (int)outputs[3]);
-    
+
     /*I turned off alpha value here so I could not draw segmentations on creatures
     The creatures weren't easily visible with a low alpha*/
     return color(r, g, b, 255);
@@ -528,7 +542,7 @@ class creature {
   float getMass() {
     return body.getMass();
   }
-  
+
   float getArmor() {  // gets the sum of armor on all segments and appendages
     float value = 0;
     for (Segment s : segments) {
@@ -537,20 +551,19 @@ class creature {
     for (Appendage a : appendages) {
       value += a.armor;
     }
-    
+
     return value;
   }
-  
-  float getDensity() { // gets the sum of density on all segments and appendages
-    float value = 0;
+
+  float getCreatureDensity() { // gets the creature's density (total mass divided by total area)
+    float area = 0;
     for (Segment s : segments) {
-      value += s.density;
+      area += s.area;
     }
     for (Appendage a : appendages) {
-      value += a.density; 
+      if (a.size > 0) area += a.area;
     }
-    
-    return value;
+    return (body.getMass()/area);
   }
 
   // can be from 2 to Genome.MAX_SEGMENTS
@@ -591,7 +604,7 @@ class creature {
   void changeHealth(int h) {
     health += h;
     senses.Set_Current_Pain(-h);
-    
+
     // data collection
     hits_by_tower++;
     hp_removed_by_tower += h;
@@ -679,7 +692,7 @@ class creature {
       body.applyForce(new Vec2(f * cos(a - (PI*1.5)), f * sin(a - (PI*1.5))), body.getWorldCenter());
       energy_locomotion = energy_locomotion - abs(2 + (f * 0.005));   // moving uses locomotion energy
       energy_locomotion = (energy_locomotion - abs((float)(torque * 0.0001)));
-      
+
       // data collection
       locomotion_used += (abs(2 + (f * 0.005)) + abs((float)(torque * 0.0001)));
     }
@@ -751,7 +764,7 @@ class creature {
     if (energy_health > 0 && health < maxHealth) {
       health = health + health_regen;
       energy_health = energy_health - regen_energy_cost;
-      
+
       // data collection
       health_used += regen_energy_cost;
     }
@@ -771,12 +784,12 @@ class creature {
     // set some shape drawing modes
     rectMode(CENTER);
     ellipseMode(CENTER);
-       
+
       pushMatrix();// Stores the current drawing reference frame
     translate(pos.x, pos.y);  // Move the drawing reference frame to the creature's position
     rotate(-a);  // Rotate the drawing reference frame to point in the direction of the creature
     stroke(0);   // Draw polygons with edges
-    
+
 
     stroke(0);
 
@@ -806,18 +819,18 @@ class creature {
       }
       endShape(CLOSE);
     }
-    
+
     //strokeWeight(1);
     // Add some eyespots
     Vec2 eye = segments.get(round(numSegments*0.74)).frontPoint;;
     senses.Draw_Eyes(eye, this);
     popMatrix();
-    
+
     pushMatrix();
     noStroke();
     senses.Draw_Sense(pos.x, pos.y, body.getAngle());
     popMatrix();
-    
+
     pushMatrix(); // Draws a "health" bar above the creature
     translate(pos.x, pos.y);
     noFill();

--- a/population.pde
+++ b/population.pde
@@ -271,7 +271,7 @@ class population {
       c_traitsRow.setInt("   Creature ID   ", c.num);
       c_traitsRow.setFloat("   Mass   "     , c.getMass());
       c_traitsRow.setFloat("   Width   "    , c.getWidth());
-      c_traitsRow.setFloat("   Density   "  , c.getDensity());
+      c_traitsRow.setFloat("   Density   "  , c.getCreatureDensity());
       c_traitsRow.setFloat("   Armor   "    , c.getArmor());
       //c_traitsRow.setFloat("   Wing #   ", );
       //c_traitsRow.setFloat("   Wing Size   ", );
@@ -284,7 +284,7 @@ class population {
       // Update creature trait averages data
       massAvg  += c.getMass();
       widthAvg += c.getWidth();
-      denseAvg += c.getDensity();
+      denseAvg += c.getCreatureDensity();
       armorAvg += c.getArmor();
       velAvg   += c.maxMovementSpeed;
       hpAvg    += c.maxHealth;


### PR DESCRIPTION
So there are three getDensity functions in creature.pde. I wrote two of them, and they are in the segment class and the appendage class respectively. Those two serve to give each individual segment or appendage its density, by retrieving its density from the genome, and then mapping it to the phenome using two simple rules: if the value is negative, density approaches zero asympototically from 10, and otherwise, the value is positive and density grows as 10 plus the square root of the evolved value. I got this code from Terry as part of the earliest version of the game, when a creature had one density for its entire body. There is a third getDensity function with the exact same parameters (none) which exists in the creature class. it is not the original getDensity function that Terry wrote into the creature class, as I removed that one when I made density bodypart-specific. Before this PR, this function returned the sum of all of the densities of all the body parts, even the ones that didn’t exist yet. The density values for the body parts that don't exist yet (segments' appendages that haven't grown yet) are not initialized, so could be any random number. This was not the only problem, as the sum of the densities is not a very useful number, as there can be almost any number of body parts. Even summing the densities of the body parts and then dividing by the total number of body parts wouldn't be very useful because some body parts are quite small and therefore don't contribute to overall density very much. I changed the function so that it returns the creatures' true densities. Total mass divided by total area. I just want to make sure before we merge this, was the sum of the densities intended? Because this function was only called by the data collection system does the data collection system want the sum of all the different densities for some reason? I’m tellin you its not very useful to know.
