### PR TITLE
fixed reproduction and game slow down

### DIFF
--- a/creature.pde
+++ b/creature.pde
@@ -584,6 +584,31 @@ class creature {
 
   // This function removes the body from the box2d world
   void killBody() {
+    // if its no longer alive creature spawns 2 gametes in a 
+    // radius of 5 tiles and the body can be killed - otherwise it
+    // still "in" the world.  Have to make sure the body isn't
+    // referenced elsewhere
+    
+    // Spawn gametes
+    int dx = (int)random(-5, 6); //from -5 to 5 (6 is not included)
+    int dy = (int)random(-5, 6);
+    int energy = (int) (baseGameteEnergy * (1+genome.avg(gameteEnergy)));
+    Vec2 pos = box2d.getBodyPixelCoord(body);
+    
+    int posX = (int)(pos.x / cellWidth);
+    int posY = (int)(pos.y / cellHeight);
+    
+    // Use one of each chromosome from getGametes.
+    ArrayList<Genome.Chromosome> newGametes = new ArrayList<Genome.Chromosome>(2);
+    newGametes = genome.getGametes();
+    
+    Gamete g1 = new Gamete(posX + dx, posY + dy, energy, newGametes.get(0));
+    Gamete g2 = new Gamete(posX - dx, posY - dy, energy, newGametes.get(1));
+                           
+    gameteStack.add(g1);
+    gameteStack.add(g2);
+      
+    // Delete the body
     box2d.destroyBody(body);
   }
 
@@ -734,29 +759,9 @@ class creature {
     // in the world, still exists for reproducton
     if (health <= 0) {
       alive = false;
-      // if its no longer alive creature spawns 2 gametes in a 
-      //radius of 5 tiles and the body can be killed - otherwise it
+      // if its no longer alive the body can be killed - otherwise it
       // still "in" the world.  Have to make sure the body isn't
       // referenced elsewhere
-      
-      //spawn gametes
-      int dx = (int)random(-5, 6); //from -5 to 5 (6 is not included)
-      int dy = (int)random(-5, 6);
-      int energy = (int) (baseGameteEnergy * (1+genome.avg(gameteEnergy)));
-      Vec2 pos = box2d.getBodyPixelCoord(body);
-      
-      int posX = (int)(pos.x / cellWidth);
-      int posY = (int)(pos.y / cellHeight);
-      
-      // Use one of each chromosome from getGametes.
-      ArrayList<Genome.Chromosome> newGametes = new ArrayList<Genome.Chromosome>(2);
-      newGametes = genome.getGametes();
-      
-      Gamete g1 = new Gamete(posX + dx, posY + dy, energy, newGametes.get(0));
-      Gamete g2 = new Gamete(posX - dx, posY - dy, energy, newGametes.get(1));
-                             
-      gameteStack.add(g1);
-      gameteStack.add(g2);
       
       //delete the body
       killBody();

--- a/sound.pde
+++ b/sound.pde
@@ -10,6 +10,8 @@ public class Sounds extends Thread {
   public void run () {
     a.rewind();
     a.play();
+    delay(2000);
+    a.close();
   }
 }
 


### PR DESCRIPTION
Reproduction fix:
- Surviving creatures now also spawn 2 gametes at end of round.  before only killed creatures were spawning these.

Slowdown fix:
- AudioPlayer threads needed to be closed after file finishes playing.
- Now threads only last 2 seconds max.  This should be edited more to account for the files actual length.
