### PR TITLE
Add copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,45 @@
+The MIT License (MIT)
+
+Copyright (c) Spring 2015 University of Idaho CS 404 Class
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+Copyright Holders:
+
+Andrew Schwartzmeyer
+Asia Lauren
+BIOEvolveTD
+CaptJumprope
+David Streett
+Higles
+Ian Westrope
+MillionYearRain
+Mkeyes16
+Rithcasper
+Rookzer0
+Samuel Neff
+Terry Soule
+Xihark
+anakhaETD
+chaseguyer
+dstreett
+endergeek123
+tanimoti
+thom5468
+yama4272


### PR DESCRIPTION
I used `git shortlog -s` to generate a sorted authors list from
contributions to the repository.

This fixes #111 

Some teams want to be able to share the repository with the students involved in their lesson plan, which requires open-sourcing the project. This is the MIT License, which is used by many academic projects, and absolves us of liability if our code breaks or causes any harm, and otherwise pretty much gives away the code for anyone to use however they want (including sub-licensing).

@dstreett is going to print this off and @tsoule88 will pass it around. Each copyright holder needs to sign the sheet to accept the license.

Once this is done, @tsoule88  can open-source the repository.
